### PR TITLE
Port forwarding for postgres container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
       POSTGRES_PASSWORD: 'postgres'
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
   web:
     build: .
     environment:


### PR DESCRIPTION
To connect PostgreSQL on the host machine
---
psql -h 127.0.0.1 -p 5432 -U postgres -W postgres