### PR TITLE
Mount only app dir

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - GITHUB_SECRET
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
-      - .:/myapp
+      - ./app:/myapp/app
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
Mounting all files can cause unexepected behavior.
For example, node_modules is ignored git.