### PR TITLE
Disable volume mount for postgres

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,6 @@ services:
     image: postgres
     environment:
       POSTGRES_PASSWORD: 'postgres'
-    volumes:
-      - ./tmp/db:/var/lib/postgresql/data
     ports:
       - "5432:5432"
   web:


### PR DESCRIPTION
I'm not sure but some user report that permission of "tmp/db" is changed:
>drwx------ 19  999 kamo 4096 May 14 00:09 db

By this change, Data is lost when container down and up,
we accept the downside to keep productivity.